### PR TITLE
Change usage command to include --global flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Contributions are welcome :-) Read [CONTRIBUTING.md](CONTRIBUTING.md).
 ### Installing
 
 ```
-$ dotnet tool install -g NuLink --version 0.1.0-beta2
+$ dotnet tool install --global NuLink --version 0.1.0-beta2
 ```
 
 ### Linking a package to local sources


### PR DESCRIPTION
When I first ran the command in the readme (without --global) I got the following error:

```
The tool package could not be restored.
Tool 'nulink' failed to install. This failure may have been caused by:

* You are attempting to install a preview release and did not use the --version option to specify the version.
* A package by this name was found, but it was not a .NET Core tool.
* The required NuGet feed cannot be accessed, perhaps because of an Internet connection problem.
* You mistyped the name of the tool.

For more reasons, including package naming enforcement, visit https://aka.ms/failure-installing-tool
```

Then I noticed on the [nuget package page](https://www.nuget.org/packages/NuLink) it has the following:

```
dotnet tool install --global NuLink --version 0.1.0-beta2
```

This worked. I thought I'd do a PR to help other users in the future.