### PR TITLE
Add ability to link multiple referenced packages at once

### DIFF
--- a/source/NuLink.Cli/INuLinkCommand.cs
+++ b/source/NuLink.Cli/INuLinkCommand.cs
@@ -2,6 +2,6 @@ namespace NuLink.Cli
 {
     public interface INuLinkCommand
     {
-        int Execute(NuLinkCommandOptions options);
+        void Execute(NuLinkCommandOptions options);
     }
 }

--- a/source/NuLink.Cli/LinkCommand.cs
+++ b/source/NuLink.Cli/LinkCommand.cs
@@ -31,10 +31,10 @@ namespace NuLink.Cli
                 if (options.Mode == NuLinkCommandOptions.LinkMode.SingleToAll)
                 {
                     localProjectPath = GetAllProjects(options.RootDirectory).
-                        FirstOrDefault(p => p.Contains(requestedPackage.PackageId));
+                        FirstOrDefault(proj => proj.Contains(requestedPackage.PackageId + ".csproj"));
                 }
                 
-                LinkPackage(requestedPackage, localProjectPath);
+                LinkPackage(requestedPackage, localProjectPath, options.Mode == NuLinkCommandOptions.LinkMode.SingleToSingle);
             }
             else
             {
@@ -42,17 +42,27 @@ namespace NuLink.Cli
 
                 foreach (var package in allPackages)
                 {
-                    localProjectPath = allProjectsInRoot.FirstOrDefault(proj => proj.Contains(package.PackageId));
-                    LinkPackage(package, localProjectPath);
+                    localProjectPath = allProjectsInRoot.FirstOrDefault(proj => proj.Contains(package.PackageId + ".csproj"));
+                    LinkPackage(package, localProjectPath, false);
                 }
             }
         }
 
-        private void LinkPackage(PackageReferenceInfo requestedPackage, string localProjectPath)
+        private void LinkPackage(PackageReferenceInfo requestedPackage, string localProjectPath, bool singleMode)
         {
             if (localProjectPath == null)
             {
-                _ui.ReportError(() => $"Error: Cannot find corresponding project to package {requestedPackage.PackageId}");
+                if (singleMode)
+                {
+                    _ui.ReportError(() =>
+                        $"Error: Cannot find corresponding project to package {requestedPackage.PackageId}");
+                }
+                else
+                {
+                    _ui.ReportLow(() =>
+                        $"Info: Cannot find corresponding project to package {requestedPackage.PackageId}");
+                }
+
                 return;
             }
 

--- a/source/NuLink.Cli/LinkCommand.cs
+++ b/source/NuLink.Cli/LinkCommand.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection.Metadata.Ecma335;
@@ -20,42 +21,86 @@ namespace NuLink.Cli
             _ui.ReportMedium(() =>
                 $"Checking package references in {(options.ProjectIsSolution ? "solution" : "project")}: {options.ConsumerProjectPath}");
 
-            var requestedPackage = GetPackageInfo();
-            var status = requestedPackage.CheckStatus();
-            var linkTargetPath = Path.Combine(Path.GetDirectoryName(options.LocalProjectPath), "bin", "Debug");
+            var allPackages = GetAllPackages(options);
 
-            ValidateOperation();
+            IEnumerable<string> allProjectsInRoot;
+            PackageReferenceInfo requestedPackage = null;
+            PackageStatusInfo status = null;
+            string localProjectPath = options.LocalProjectPath;
+
+            switch (options.Mode)
+            {
+                case NuLinkCommandOptions.LinkMode.Single:
+                    requestedPackage = GetPackage(allPackages, options.PackageId);
+                    status = requestedPackage.CheckStatus();
+                    break;
+
+                case NuLinkCommandOptions.LinkMode.PackageToAll:
+                    requestedPackage = GetPackage(allPackages, options.PackageId);
+                    status = requestedPackage.CheckStatus();
+                    allProjectsInRoot = GetAllProjects(options.RootDirectory);
+                    localProjectPath = allProjectsInRoot.FirstOrDefault(proj => proj.Contains(requestedPackage.PackageId));
+                    break;
+
+                case NuLinkCommandOptions.LinkMode.All:
+                    allProjectsInRoot = GetAllProjects(options.RootDirectory);
+
+                    foreach (var package in allPackages)
+                    {
+                        requestedPackage = package;
+                        status = requestedPackage.CheckStatus();
+                        localProjectPath = allProjectsInRoot.FirstOrDefault(proj => proj.Contains(requestedPackage.PackageId));
+                        ExecuteForPackage(requestedPackage, status, options, localProjectPath);
+                    }
+
+                    return 0;
+            }
+
+            return ExecuteForPackage(requestedPackage, status, options, localProjectPath);
+        }
+
+        private int ExecuteForPackage(PackageReferenceInfo requestedPackage, PackageStatusInfo status, NuLinkCommandOptions options, string localProjectPath)
+        {
+            if (localProjectPath == null)
+            {
+                _ui.ReportError(() => $"Error: Cannot find corresponding project to package {requestedPackage.PackageId}");
+                return 1;
+            }
+
+            var linkTargetPath = Path.Combine(Path.GetDirectoryName(localProjectPath), "bin", "Debug");
+
+            if (!ValidateOperation())
+            {
+                return 1;
+            }
+
             PerformOperation();
-            
+
             _ui.ReportSuccess(() => $"Linked {requestedPackage.LibFolderPath}");
             _ui.ReportSuccess(() => $" -> {linkTargetPath}", ConsoleColor.Magenta);
             return 0;
 
-            PackageReferenceInfo GetPackageInfo()
-            {
-                var allProjects = new WorkspaceLoader().LoadProjects(options.ConsumerProjectPath, options.ProjectIsSolution);
-                var referenceLoader = new PackageReferenceLoader(_ui);
-                var allPackages = referenceLoader.LoadPackageReferences(allProjects);
-                var package = allPackages.FirstOrDefault(p => p.PackageId == options.PackageId);
-                return package ?? throw new Exception($"Error: Package not referenced: {options.PackageId}");
-            }
-            
-            void ValidateOperation()
+            bool ValidateOperation()
             {
                 if (!status.LibFolderExists)
                 {
-                    throw new Exception($"Error: Cannot link package {options.PackageId}: 'lib' folder not found, expected {requestedPackage.LibFolderPath}");
+                    _ui.ReportError(() => $"Error: Cannot link package {options.PackageId}: 'lib' folder not found, expected {requestedPackage.LibFolderPath}");
+                    return false;
                 }
 
                 if (status.IsLibFolderLinked)
                 {
-                    throw new Exception($"Error: Package {requestedPackage.PackageId} is already linked to {status.LibFolderLinkTargetPath}");
+                    _ui.ReportError(() => $"Error: Package {requestedPackage.PackageId} is already linked to {status.LibFolderLinkTargetPath}");
+                    return false;
                 }
 
                 if (!Directory.Exists(linkTargetPath))
                 {
-                    throw new Exception($"Error: Target link directory doesn't exist: {linkTargetPath}");
+                    _ui.ReportError(() => $"Error: Target link directory doesn't exist: {linkTargetPath}");
+                    return false;
                 }
+
+                return true;
             }
 
             void PerformOperation()
@@ -66,13 +111,14 @@ namespace NuLink.Cli
                 }
                 else
                 {
-                    _ui.ReportWarning(() => $"Warning: backup folder was not expected to exist: {requestedPackage.LibBackupFolderPath}");
+                    _ui.ReportWarning(() =>
+                        $"Warning: backup folder was not expected to exist: {requestedPackage.LibBackupFolderPath}");
                 }
 
                 try
                 {
                     SymbolicLinkWithDiagnostics.Create(
-                        fromPath: requestedPackage.LibFolderPath, 
+                        fromPath: requestedPackage.LibFolderPath,
                         toPath: linkTargetPath);
                 }
                 catch
@@ -96,10 +142,31 @@ namespace NuLink.Cli
                     _ui.ReportError(() => "--- MANUAL RECOVERY INSTRUCTIONS ---");
                     _ui.ReportError(() => $"1. Go to {Path.GetDirectoryName(requestedPackage.LibFolderPath)}");
                     _ui.ReportError(() => $"2. Rename '{Path.GetFileName(requestedPackage.LibBackupFolderPath)}'" +
-                                      $" to '{Path.GetFileName(requestedPackage.LibFolderPath)}'");
+                                          $" to '{Path.GetFileName(requestedPackage.LibFolderPath)}'");
                     _ui.ReportError(() => "--- END OF RECOVERY INSTRUCTIONS ---");
                 }
             }
+        }
+
+        private PackageReferenceInfo GetPackage(HashSet<PackageReferenceInfo> allPackages, string packageId)
+        {
+            var package = allPackages.FirstOrDefault(p => p.PackageId == packageId);
+            return package ?? throw new Exception($"Error: Package not referenced: {packageId}");
+        }
+
+        private HashSet<PackageReferenceInfo> GetAllPackages(NuLinkCommandOptions options)
+        {
+            var allProjects = new WorkspaceLoader().LoadProjects(options.ConsumerProjectPath, options.ProjectIsSolution);
+            var referenceLoader = new PackageReferenceLoader(_ui);
+            var allPackages = referenceLoader.LoadPackageReferences(allProjects);
+            return allPackages;
+        }
+
+        private IEnumerable<string> GetAllProjects(string rootDir)
+        {
+            var slnPaths = Directory.GetFiles(rootDir, "*.sln", SearchOption.AllDirectories);
+            var allProjects = new WorkspaceLoader().LoadProjects(slnPaths).Select(proj => proj.ProjectFile.Path);
+            return allProjects;
         }
     }
 }

--- a/source/NuLink.Cli/LinkCommand.cs
+++ b/source/NuLink.Cli/LinkCommand.cs
@@ -52,16 +52,9 @@ namespace NuLink.Cli
         {
             if (localProjectPath == null)
             {
-                if (singleMode)
-                {
-                    _ui.ReportError(() =>
-                        $"Error: Cannot find corresponding project to package {requestedPackage.PackageId}");
-                }
-                else
-                {
-                    _ui.ReportLow(() =>
-                        $"Info: Cannot find corresponding project to package {requestedPackage.PackageId}");
-                }
+                _ui.Report(singleMode ? VerbosityLevel.Error : VerbosityLevel.Low, () =>
+                    $"{(singleMode ? string.Concat(VerbosityLevel.Error.ToString(), ": ") : string.Empty)}" +
+                    $"Cannot find corresponding project to package {requestedPackage.PackageId}");
 
                 return;
             }
@@ -89,7 +82,10 @@ namespace NuLink.Cli
 
                 if (status.IsLibFolderLinked)
                 {
-                    _ui.ReportError(() => $"Error: Package {requestedPackage.PackageId} is already linked to {status.LibFolderLinkTargetPath}");
+                    _ui.Report(singleMode ? VerbosityLevel.Error : VerbosityLevel.Low, () =>
+                        $"{(singleMode ? string.Concat(VerbosityLevel.Error.ToString(), ": ") : string.Empty)}" +
+                        $"Package {requestedPackage.PackageId} is already linked to {status.LibFolderLinkTargetPath}");
+
                     return false;
                 }
 

--- a/source/NuLink.Cli/LinkCommand.cs
+++ b/source/NuLink.Cli/LinkCommand.cs
@@ -24,11 +24,11 @@ namespace NuLink.Cli
             var allPackages = GetAllPackages(options);
             var localProjectPath = options.LocalProjectPath;
 
-            if (options.Mode == NuLinkCommandOptions.LinkMode.Single)
+            if (options.Mode != NuLinkCommandOptions.LinkMode.AllToAll)
             {
                 var requestedPackage = GetPackage(allPackages, options.PackageId);
 
-                if (options.Mode == NuLinkCommandOptions.LinkMode.PackageToAll)
+                if (options.Mode == NuLinkCommandOptions.LinkMode.SingleToAll)
                 {
                     localProjectPath = GetAllProjects(options.RootDirectory).
                         FirstOrDefault(p => p.Contains(requestedPackage.PackageId));
@@ -36,7 +36,7 @@ namespace NuLink.Cli
                 
                 LinkPackage(requestedPackage, localProjectPath);
             }
-            else if (options.Mode == NuLinkCommandOptions.LinkMode.All)
+            else
             {
                 var allProjectsInRoot = GetAllProjects(options.RootDirectory).ToList();
 

--- a/source/NuLink.Cli/NuLinkCommandOptions.cs
+++ b/source/NuLink.Cli/NuLinkCommandOptions.cs
@@ -4,26 +4,38 @@ namespace NuLink.Cli
 {
     public class NuLinkCommandOptions
     {
+        public enum LinkMode
+        {
+            Single,
+            PackageToAll,
+            All
+        }
+
         public NuLinkCommandOptions(
             string consumerProjectPath, 
+			string rootDirectory = null,
             string packageId = null, 
             bool dryRun = false, 
             bool bareUI = false,
             string localProjectPath = null)
         {
             ConsumerProjectPath = consumerProjectPath;
+			RootDirectory = rootDirectory;
             PackageId = packageId;
             DryRun = dryRun;
             BareUI = bareUI;
             LocalProjectPath = localProjectPath;
             ProjectIsSolution = ConsumerProjectPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase);
+            Mode = rootDirectory != null ? packageId == null ? LinkMode.All : LinkMode.PackageToAll : LinkMode.Single;
         }
 
         public string ConsumerProjectPath { get; }
         public bool ProjectIsSolution { get; }
+        public string RootDirectory { get; }
         public string PackageId { get; }
         public string LocalProjectPath { get; }
         public bool DryRun { get; }
         public bool BareUI { get; }
+        public LinkMode Mode { get; }
     }
 }

--- a/source/NuLink.Cli/NuLinkCommandOptions.cs
+++ b/source/NuLink.Cli/NuLinkCommandOptions.cs
@@ -12,15 +12,15 @@ namespace NuLink.Cli
         }
 
         public NuLinkCommandOptions(
-            string consumerProjectPath, 
-			string rootDirectory = null,
-            string packageId = null, 
-            bool dryRun = false, 
+            string consumerProjectPath,
+            string rootDirectory = null,
+            string packageId = null,
+            bool dryRun = false,
             bool bareUI = false,
             string localProjectPath = null)
         {
             ConsumerProjectPath = consumerProjectPath;
-			RootDirectory = rootDirectory;
+            RootDirectory = rootDirectory;
             PackageId = packageId;
             DryRun = dryRun;
             BareUI = bareUI;

--- a/source/NuLink.Cli/NuLinkCommandOptions.cs
+++ b/source/NuLink.Cli/NuLinkCommandOptions.cs
@@ -6,9 +6,9 @@ namespace NuLink.Cli
     {
         public enum LinkMode
         {
-            Single,
-            PackageToAll,
-            All
+            SingleToSingle,
+            SingleToAll,
+            AllToAll
         }
 
         public NuLinkCommandOptions(
@@ -26,7 +26,7 @@ namespace NuLink.Cli
             BareUI = bareUI;
             LocalProjectPath = localProjectPath;
             ProjectIsSolution = ConsumerProjectPath.EndsWith(".sln", StringComparison.OrdinalIgnoreCase);
-            Mode = rootDirectory != null ? packageId == null ? LinkMode.All : LinkMode.PackageToAll : LinkMode.Single;
+            Mode = rootDirectory != null ? packageId == null ? LinkMode.AllToAll : LinkMode.SingleToAll : LinkMode.SingleToSingle;
         }
 
         public string ConsumerProjectPath { get; }

--- a/source/NuLink.Cli/Program.cs
+++ b/source/NuLink.Cli/Program.cs
@@ -49,14 +49,14 @@ namespace NuLink.Cli
                 },
                 new Command("link", HelpText.LinkCommand, handler: HandleLink()) {
                     consumerOption,
-					rootDirOption,
+                    rootDirOption,
                     packageOption,
                     localProjectOption,
                     dryRunOption
                 },
                 new Command("unlink", HelpText.UnlinkCommand, handler: HandleUnlink()) {
                     consumerOption,
-					rootDirOption,
+                    rootDirOption,
                     packageOption,
                     dryRunOption
                 }
@@ -79,7 +79,7 @@ namespace NuLink.Cli
             CommandHandler.Create<string, string, string, string, bool>((consumer, rootDir, package, local, dryRun) => {
                 var options = new NuLinkCommandOptions(
                     ValidateConsumerProject(consumer), 
-					rootDir,
+                    rootDir,
                     package,
                     localProjectPath: local,
                     dryRun: dryRun);
@@ -95,7 +95,7 @@ namespace NuLink.Cli
             CommandHandler.Create<string, string, string, bool>((consumer, rootDir, package, dryRun) => {
                 var options = new NuLinkCommandOptions(
                     ValidateConsumerProject(consumer), 
-					rootDir,
+                    rootDir,
                     package,
                     dryRun: dryRun);
                 return ExecuteCommand(

--- a/source/NuLink.Cli/Program.cs
+++ b/source/NuLink.Cli/Program.cs
@@ -56,7 +56,6 @@ namespace NuLink.Cli
                 },
                 new Command("unlink", HelpText.UnlinkCommand, handler: HandleUnlink()) {
                     consumerOption,
-                    rootDirOption,
                     packageOption,
                     dryRunOption
                 }
@@ -92,17 +91,15 @@ namespace NuLink.Cli
             });
 
         private static ICommandHandler HandleUnlink() => 
-            CommandHandler.Create<string, string, string, bool>((consumer, rootDir, package, dryRun) => {
+            CommandHandler.Create<string, string, bool>((consumer, package, dryRun) => {
                 var options = new NuLinkCommandOptions(
                     ValidateConsumerProject(consumer), 
-                    rootDir,
-                    package,
+                    packageId: package,
                     dryRun: dryRun);
                 return ExecuteCommand(
                     "unlink", 
                     options, 
-                    options.ConsumerProjectPath != null &&
-                    (ValidateRootDirectory(rootDir) || options.PackageId != null));
+                    options.ConsumerProjectPath != null);
             });
         
         private static int ExecuteCommand(

--- a/source/NuLink.Cli/StatusCommand.cs
+++ b/source/NuLink.Cli/StatusCommand.cs
@@ -12,7 +12,7 @@ namespace NuLink.Cli
             _ui = ui;
         }
 
-        public int Execute(NuLinkCommandOptions options)
+        public void Execute(NuLinkCommandOptions options)
         {
             _ui.ReportMedium(() =>
                 $"Checking status of packages in {(options.ProjectIsSolution ? "solution" : "project")}: {options.ConsumerProjectPath}");
@@ -33,8 +33,6 @@ namespace NuLink.Cli
                     PrintPackage(package, status);
                 }
             }
-
-            return 0;
 
             void PrintPackage(PackageReferenceInfo reference, PackageStatusInfo status)
             {

--- a/source/NuLink.Cli/UnlinkCommand.cs
+++ b/source/NuLink.Cli/UnlinkCommand.cs
@@ -26,7 +26,7 @@ namespace NuLink.Cli
             {
                 foreach (var package in allPackages)
                 {
-                    UnlinkPackage(package);
+                    UnlinkPackage(package, true);
                 }
 
                 return;
@@ -40,10 +40,10 @@ namespace NuLink.Cli
                 return;
             }
 
-            UnlinkPackage(requestedPackage);
+            UnlinkPackage(requestedPackage, false);
         }
 
-        private void UnlinkPackage(PackageReferenceInfo requestedPackage)
+        private void UnlinkPackage(PackageReferenceInfo requestedPackage, bool allPackages)
         {
             var status = requestedPackage.CheckStatus();
 
@@ -55,7 +55,14 @@ namespace NuLink.Cli
 
             if (!status.IsLibFolderLinked)
             {
-                _ui.ReportError(() => $"Error: Package {requestedPackage.PackageId} is not linked.");
+                if (allPackages)
+                {
+                    _ui.ReportLow(() => $"Info: Package {requestedPackage.PackageId} is not linked.");
+                }
+                else
+                {
+                    _ui.ReportError(() => $"Error: Package {requestedPackage.PackageId} is not linked.");
+                }
                 return;
             }
 

--- a/source/NuLink.Cli/UnlinkCommand.cs
+++ b/source/NuLink.Cli/UnlinkCommand.cs
@@ -47,18 +47,18 @@ namespace NuLink.Cli
         {
             var status = requestedPackage.CheckStatus();
 
-            if (!status.LibFolderExists)
-            {
-                _ui.ReportError(() => $"Error: Cannot unlink package {requestedPackage.PackageId}: 'lib' folder not found, expected {requestedPackage.LibFolderPath}");
-                return;
-            }
-
             if (!status.IsLibFolderLinked)
             {
                 _ui.Report(allPackages ? VerbosityLevel.Low : VerbosityLevel.Error, () =>
                     $"{(allPackages ? string.Empty : string.Concat(VerbosityLevel.Error.ToString(), ": "))}" +
                     $"Package {requestedPackage.PackageId} is not linked.");
 
+                return;
+            }
+
+            if (!status.LibFolderExists)
+            {
+                _ui.ReportError(() => $"Error: Cannot unlink package {requestedPackage.PackageId}: 'lib' folder not found, expected {requestedPackage.LibFolderPath}");
                 return;
             }
 

--- a/source/NuLink.Cli/UnlinkCommand.cs
+++ b/source/NuLink.Cli/UnlinkCommand.cs
@@ -55,14 +55,10 @@ namespace NuLink.Cli
 
             if (!status.IsLibFolderLinked)
             {
-                if (allPackages)
-                {
-                    _ui.ReportLow(() => $"Info: Package {requestedPackage.PackageId} is not linked.");
-                }
-                else
-                {
-                    _ui.ReportError(() => $"Error: Package {requestedPackage.PackageId} is not linked.");
-                }
+                _ui.Report(allPackages ? VerbosityLevel.Low : VerbosityLevel.Error, () =>
+                    $"{(allPackages ? string.Empty : string.Concat(VerbosityLevel.Error.ToString(), ": "))}" +
+                    $"Package {requestedPackage.PackageId} is not linked.");
+
                 return;
             }
 

--- a/source/NuLink.Cli/UnlinkCommand.cs
+++ b/source/NuLink.Cli/UnlinkCommand.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 

--- a/source/NuLink.Cli/UnlinkCommand.cs
+++ b/source/NuLink.Cli/UnlinkCommand.cs
@@ -22,7 +22,7 @@ namespace NuLink.Cli
             var referenceLoader = new PackageReferenceLoader(_ui);
             var allPackages = referenceLoader.LoadPackageReferences(allProjects);
 
-            if (options.Mode == NuLinkCommandOptions.LinkMode.All)
+            if (options.Mode == NuLinkCommandOptions.LinkMode.AllToAll)
             {
                 foreach (var package in allPackages)
                 {

--- a/source/NuLink.Cli/UnlinkCommand.cs
+++ b/source/NuLink.Cli/UnlinkCommand.cs
@@ -22,7 +22,7 @@ namespace NuLink.Cli
             var referenceLoader = new PackageReferenceLoader(_ui);
             var allPackages = referenceLoader.LoadPackageReferences(allProjects);
 
-            if (options.Mode == NuLinkCommandOptions.LinkMode.AllToAll)
+            if (options.PackageId == null)
             {
                 foreach (var package in allPackages)
                 {

--- a/source/NuLink.Cli/WorkspaceLoader.cs
+++ b/source/NuLink.Cli/WorkspaceLoader.cs
@@ -20,5 +20,17 @@ namespace NuLink.Cli
                 return new[] { analyzerManager.GetProject(filePath) };
             }
         }
+
+        public IEnumerable<ProjectAnalyzer> LoadProjects(string[] solutionsFilePaths)
+        {
+            List<ProjectAnalyzer> projects = new List<ProjectAnalyzer>();
+
+            foreach (var path in solutionsFilePaths)
+            {
+                projects.AddRange(LoadProjects(path, true));
+            }
+
+            return projects;
+        }
     }
 }

--- a/source/NuLink.sln
+++ b/source/NuLink.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29424.173
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuLink.Cli", "NuLink.Cli\NuLink.Cli.csproj", "{DE89E25B-0FA5-4C12-A085-C419A0EE38CA}"
 EndProject
@@ -15,9 +15,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DE89E25B-0FA5-4C12-A085-C419A0EE38CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -44,5 +41,11 @@ Global
 		{00A1F74F-07C0-443C-8B49-CB172E1D6DF5}.Release|x64.Build.0 = Release|Any CPU
 		{00A1F74F-07C0-443C-8B49-CB172E1D6DF5}.Release|x86.ActiveCfg = Release|Any CPU
 		{00A1F74F-07C0-443C-8B49-CB172E1D6DF5}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4C7EB84D-B529-447C-81C4-0996D7D3A09D}
 	EndGlobalSection
 EndGlobal

--- a/source/NuLink.sln
+++ b/source/NuLink.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29424.173
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NuLink.Cli", "NuLink.Cli\NuLink.Cli.csproj", "{DE89E25B-0FA5-4C12-A085-C419A0EE38CA}"
 EndProject
@@ -15,6 +15,9 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{DE89E25B-0FA5-4C12-A085-C419A0EE38CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -41,11 +44,5 @@ Global
 		{00A1F74F-07C0-443C-8B49-CB172E1D6DF5}.Release|x64.Build.0 = Release|Any CPU
 		{00A1F74F-07C0-443C-8B49-CB172E1D6DF5}.Release|x86.ActiveCfg = Release|Any CPU
 		{00A1F74F-07C0-443C-8B49-CB172E1D6DF5}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
-	EndGlobalSection
-	GlobalSection(ExtensibilityGlobals) = postSolution
-		SolutionGuid = {4C7EB84D-B529-447C-81C4-0996D7D3A09D}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Fixes nwheels-io/NuLink#6

Tool can now be run with:
- `nulink link -r [repos_root_dir]` - if run on the solution's (`.sln`) directory, will link all referenced packages in all projects within the solution. If run on the project's (`.csproj`) directory, will link all referenced packages in such project. The user only needs to provide the directory where all repositories are located to the `-r` option.
- `nulink unlink` - if run without options, it will unlink all packages from solution/project, depending on where command is ran.